### PR TITLE
initUrls honors getDirectory singature providing hash "file" instead of ...

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -283,7 +283,7 @@ FileInfo.prototype.safeName = function () {
 FileInfo.prototype.initUrls = function (req, form) {
   if (!this.error) {
     var that = this,
-      subDirectory = options.getDirectory(this.name, form.formFields),
+      subDirectory = options.getDirectory(that, form.formFields),
       baseUrl = (options.ssl ? 'https:' : 'http:') +
         '//' + req.headers.host + options.uploadUrl;
     this.url = baseUrl + (subDirectory ? (subDirectory + '/') : '') + encodeURIComponent(this.name);
@@ -461,4 +461,3 @@ var checkCreateDirectory = function(dir) {
 
 RoutePolicy.declare(options.uploadUrl, 'network');
 WebApp.connectHandlers.use(options.uploadUrl, UploadServer.serve);
-


### PR DESCRIPTION
Tomi,

Great package thanks. I just came across this scenario where I build a custom directory path. Down the road, the URL the package computes internally wasn't correct since the parameter used to execute getDirectory wasn't the full object file, but only the file name.

Let me know how I can help further.

Kind regards,
Alex