### PR TITLE
Allow a 404 image to be specified instead of the 404 text response when image not found

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -208,22 +208,16 @@ UploadServer = {
           stats = fs.lstatSync(filename); // throws if path doesn't exist
         } catch (e) {
           
-          console.log('options.notFoundImage');
-          console.log(options.notFoundImage);
-          
           if (options.notFoundImage) {    
             filename = path.join(options.uploadDir, options.notFoundImage);
-            console.log(filename)
             
             try {
               stats = fs.lstatSync(filename);
               
             } catch (e) {
-              console.log('couldnt open 404 image' );
               exitWith404 = true;
             } 
           }else {
-            console.log('no 404 image set, writing 404 string');
             exitWith404 = true;
           }
           

--- a/upload_server.js
+++ b/upload_server.js
@@ -64,7 +64,8 @@ var options = {
     "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "zip": "application/zip, application/x-compressed-zip",
     "txt": "text/plain"
-  }
+  },
+  notFoundImage: null
   /* Uncomment and edit this section to provide the service via HTTPS:
    ssl: {
    key: fs.readFileSync('/Applications/XAMPP/etc/ssl.key/server.key'),
@@ -118,6 +119,7 @@ UploadServer = {
     if (opts.getDirectory != null) options.getDirectory = opts.getDirectory;
     if (opts.getFileName != null) options.getFileName = opts.getFileName;
     if (opts.finished != null) options.finished = opts.finished;
+    if (opts.notFoundImage != null) options.notFoundImage = opts.notFoundImage;
 
     if (opts.uploadUrl) options.uploadUrl = opts.uploadUrl;
 
@@ -200,14 +202,39 @@ UploadServer = {
         var uri = url.parse(req.url).pathname;
         var filename = path.join(options.uploadDir, unescape(uri));
         var stats;
+        var exitWith404 = false;
 
         try {
           stats = fs.lstatSync(filename); // throws if path doesn't exist
         } catch (e) {
-          res.writeHead(404, {'Content-Type': 'text/plain'});
-          res.write('404 Not Found\n');
-          res.end();
-          return;
+          
+          console.log('options.notFoundImage');
+          console.log(options.notFoundImage);
+          
+          if (options.notFoundImage) {    
+            filename = path.join(options.uploadDir, options.notFoundImage);
+            console.log(filename)
+            
+            try {
+              stats = fs.lstatSync(filename);
+              
+            } catch (e) {
+              console.log('couldnt open 404 image' );
+              exitWith404 = true;
+            } 
+          }else {
+            console.log('no 404 image set, writing 404 string');
+            exitWith404 = true;
+          }
+          
+          if (exitWith404) {
+            res.writeHead(404, {'Content-Type': 'text/plain'});
+            res.write('404 Not Found\n');
+            res.end();
+        
+            return;
+          }
+            
         }
 
         if (stats.isFile()) {


### PR DESCRIPTION
I added an option 'notFoundImage' which allows you to specify a filename within the uploadDir. If specified, this will serve this image rather than the standard 404 text if the originally requested image is not found.

This is a fairly small modification, let me know if there's any changes I can make. Hopefully it can be accepted : )