### PR TITLE
Setting maxPostSize triggers file too small error

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -109,7 +109,7 @@ UploadServer = {
     }
 
     if (opts.maxPostSize != null) options.maxPostSize = opts.maxPostSize;
-    if (opts.minFileSize != null) options.minFileSize = opts.maxPostSize;
+    if (opts.minFileSize != null) options.minFileSize = opts.minFileSize;
     if (opts.maxFileSize != null) options.maxFileSize = opts.maxFileSize;
     if (opts.acceptFileTypes != null) options.acceptFileTypes = opts.acceptFileTypes;
     if (opts.imageTypes != null) options.imageTypes = opts.imageTypes;


### PR DESCRIPTION
Due to a copy/paste error