### PR TITLE
Allow setting the format in the scaling options

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -431,7 +431,7 @@ UploadHandler.prototype.post = function () {
         imageMagick.resize({
           width: opts.width,
           height: opts.height,
-          srcPath: currentFolder + '/' + newFileName,
+          srcPath: currentFolder + '/' + newFileName + '[0]',
           dstPath: currentFolder + '/' + version + '/' + resizedFileName
         }, finish);
       });

--- a/upload_server.js
+++ b/upload_server.js
@@ -398,11 +398,20 @@ UploadHandler.prototype.post = function () {
           fs.mkdirSync(currentFolder + '/' + version);
         }
 
+        // rename target file if format was specified
+        var resizedFileName;
+        if(opts.format) {
+          resizedFileName = newFileName.substr(0, 
+            newFileName.lastIndexOf('.') + 1) + opts.format;
+        } else {
+          resizedFileName = newFileName;
+        } 
+
         imageMagick.resize({
           width: opts.width,
           height: opts.height,
           srcPath: currentFolder + '/' + newFileName,
-          dstPath: currentFolder + '/' + version + '/' + newFileName
+          dstPath: currentFolder + '/' + version + '/' + resizedFileName
         }, finish);
       });
     }


### PR DESCRIPTION
This implements https://github.com/tomitrescak/meteor-uploads/issues/85 and allows you to make sure that thumbnails always have the desired file format (typically jpeg), independently of the original file format.
