### PR TITLE
Added accessor to get the options of UploadServer

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -112,6 +112,10 @@ var options = {
 
 
 UploadServer = {
+  getOptions: function()
+  {
+    return options;	
+  },
   init: function (opts) {
     if (opts.checkCreateDirectories != null) options.checkCreateDirectories = opts.checkCreateDirectories;
 


### PR DESCRIPTION
Added an accessor for the current held "options" object. Allowing to call UploadServer.options on the server side (instead of using the one we used for initing the UploadServer…)