### PR TITLE
Fixed a fatal bug while moving a file using renaming

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -400,14 +400,23 @@ UploadHandler.prototype.post = function () {
     fileInfo.name = newFileName;
     fileInfo.path = folder + "/" + newFileName;
 
-    // move the file (support moving to different partitions)
+    // Move the file to the final destination
     var destinationFile = currentFolder + "/" + newFileName;
-    var is = fs.createReadStream(file.path);
-	var os = fs.createWriteStream(destinationFile);
-	is.pipe(os);
-	is.on('end',function() {
-    	fs.unlinkSync(file.path);
-	});
+    try 
+    {
+     	// Try moving through renameSync
+       	fs.renameSync(file.path, destinationFile)
+    }
+    catch(exception)
+    {
+    	// if moving failed, try a copy + delete instead, this to support moving work between partitions
+    	var is = fs.createReadStream(file.path);
+		var os = fs.createWriteStream(destinationFile);
+		is.pipe(os);
+		is.on('end',function() {
+    		fs.unlinkSync(file.path);
+		});
+    }
 
     if (options.imageTypes.test(fileInfo.name)) {
       Object.keys(options.imageVersions).forEach(function (version) {

--- a/upload_server.js
+++ b/upload_server.js
@@ -400,7 +400,14 @@ UploadHandler.prototype.post = function () {
     fileInfo.name = newFileName;
     fileInfo.path = folder + "/" + newFileName;
 
-    fs.renameSync(file.path, currentFolder + "/" + newFileName);
+    // move the file (support moving to different partitions)
+    var destinationFile = currentFolder + "/" + newFileName;
+    var is = fs.createReadStream(file.path);
+	var os = fs.createWriteStream(destinationFile);
+	is.pipe(os);
+	is.on('end',function() {
+    	fs.unlinkSync(file.path);
+	});
 
     if (options.imageTypes.test(fileInfo.name)) {
       Object.keys(options.imageVersions).forEach(function (version) {


### PR DESCRIPTION
Using fs.rename can only be done on the same partition. While using this package with docker, the file system is not considered as the same one in some cases which leads to an exception and crashed the meteor runtime. I fixed it thanks to: http://stackoverflow.com/questions/4568689/how-do-i-move-file-a-to-a-different-partition-or-device-in-node-js