### PR TITLE
Issue #219 Removed unneccessary additional / in situation with subdirectory usage

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -297,7 +297,7 @@ var FileInfo = function (file, req, form) {
 
   this.subDirectory = options.getDirectory(this, form.formFields);
   this.baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + req.headers.host + options.uploadUrl;
-  this.url = this.baseUrl + (this.subDirectory ? (this.subDirectory + '/') : '') + encodeURIComponent(this.name);
+  this.url = this.baseUrl + (this.subDirectory ? (this.subDirectory) : '') + encodeURIComponent(this.name);
 };
 
 FileInfo.prototype.validate = function () {
@@ -428,7 +428,7 @@ UploadHandler.prototype.post = function () {
 
     // set the file name
     fileInfo.name = newFileName;
-    fileInfo.path = folder + "/" + newFileName;
+    fileInfo.path = folder + newFileName;
 
 		var imageVersionsFunc = function() {
 			if (options.imageTypes.test(fileInfo.name)) {
@@ -467,6 +467,7 @@ UploadHandler.prototype.post = function () {
 
     // Move the file to the final destination
     var destinationFile = currentFolder + newFileName;
+
     try
     {
      	// Try moving through renameSync

--- a/upload_server.js
+++ b/upload_server.js
@@ -296,7 +296,8 @@ var FileInfo = function (file, req, form) {
   this.type = file.type;
 
   this.subDirectory = options.getDirectory(this, form.formFields);
-  this.baseUrl = (options.ssl ? 'https:' : 'http:') + '//' + req.headers.host + options.uploadUrl;
+  var ssl = req.headers.host.indexOf('localhost') > -1 || req.headers.host.indexOf('192.168.') > -1 ? false : true;
+  this.baseUrl = (ssl ? 'https:' : 'http:') + '//' + req.headers.host + options.uploadUrl;
   this.url = this.baseUrl + (this.subDirectory ? (this.subDirectory) : '') + encodeURIComponent(this.name);
 };
 


### PR DESCRIPTION
Resolved https://github.com/tomitrescak/meteor-uploads/issues/219

Now the configuration you make in UploadServer.init.getDirectory is also consistent with how files get written to disk AND return in the fileInfo object.

Usage:
```
UploadServer.init({
            tmpDir: process.env.PWD + '/.uploads/tmp',
            uploadDir: process.env.PWD + '/.uploads',
            checkCreateDirectories: true, //create the directories for you
            finished: function(fileInfo, formFields) {
                fileInfo.customField = formFields.customField;
            },
            getDirectory: function(fileInfo, formFields) {
                if(formFields.customField) {
                    // to write in subdirectory give a postfix forward slash
                    return formFields.customField+"/";
                } else {
                    // to write in root directory return empty string or null
                    return ""; 
                }
            }
        });
```
