### PR TITLE
update formidable for Node 6.x compat

### DIFF
--- a/package.js
+++ b/package.js
@@ -25,7 +25,7 @@ Package.onUse(function(api) {
 //});
 
 Npm.depends({
-  formidable: '1.0.15',
+  formidable: '1.0.17',
   imagemagick: '0.1.3',
   connect: '2.7.10'
 })


### PR DESCRIPTION
Hi - there's a newer (but not very new) update to Formidable which contains a fix to support Node 6.x:

https://github.com/felixge/node-formidable/commit/f4a3e08013b4387ec720f741204f8d3896c07b8b
https://github.com/felixge/node-formidable/issues/364
https://github.com/felixge/node-formidable/pull/404

@msj121 Any chance this can get quick attention? I have to fork this somehow, otherwise?