### PR TITLE
Changed unescape to decodeURIComponent to match encodind and decoding…

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -226,7 +226,7 @@ UploadServer = {
         setNoCacheHeaders();
 
         var uri = url.parse(req.url).pathname;
-        var filename = path.join(options.uploadDir, unescape(uri));
+        var filename = path.join(options.uploadDir, decodeURIComponent(uri));
         var stats;
 
         try {


### PR DESCRIPTION
… of escaped characters

When a file was uploaded with a filename such as "åäö.jpeg" the non english characters were decoded using the "unescape" which gives the wrong result. They should be decoded using decodeURI or decodeURIComponent.